### PR TITLE
Add missing underscore NPM dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "when": "2.7.x",
     "request": "2.30.x",
-    "promisifier": "latest"
+    "promisifier": "latest",
+    "underscore": "1.6.x"
   },
   "devDependencies": {
     "mocha": "1.16.x"


### PR DESCRIPTION
The script itself includes `require underscore`, but the package.json doesn't list it as a dependency and therefore fails when you try to deploy.
